### PR TITLE
feat: Add error handling for Google Sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,12 @@
 
         // --- AUTHENTICATION ---
         const provider = new GoogleAuthProvider();
-        signInBtn.addEventListener('click', () => signInWithPopup(auth, provider).catch(err => console.error("Sign-in error", err)));
+        signInBtn.addEventListener('click', () => {
+            signInWithPopup(auth, provider).catch(err => {
+                console.error("Sign-in error:", err);
+                alert(`Could not sign in with Google.\n\nThis may be due to a configuration issue. Please ensure this website's domain (${window.location.hostname}) is added to the list of authorized domains in your Firebase project's authentication settings.\n\nError: ${err.message}`);
+            });
+        });
         signOutBtn.addEventListener('click', () => signOut(auth));
 
         onAuthStateChanged(auth, user => {


### PR DESCRIPTION
When the Google Sign-in process fails, the error was previously only logged to the console, leaving the user with no feedback.

This change adds a user-facing alert that displays when a sign-in error occurs. The alert message informs the user about the potential cause of the issue (unauthorized domain in Firebase settings) and provides the specific error message for debugging purposes.