### PR TITLE
feat: Remove year from log history

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,12 +221,7 @@
             const past = timestamp.toDate();
             const seconds = Math.floor((now - past) / 1000);
 
-            let interval = seconds / 31536000; // year
-            if (interval > 1) {
-                const value = Math.floor(interval);
-                return `${value} year${value > 1 ? 's' : ''} ago`;
-            }
-            interval = seconds / 2592000; // month
+            let interval = seconds / 2592000; // month
             if (interval > 1) {
                 const value = Math.floor(interval);
                 return `${value} month${value > 1 ? 's' : ''} ago`;


### PR DESCRIPTION
Removes the year from the `timeAgo` function in the log history display. Durations longer than a month will now be displayed in months, even if they exceed a year.