### PR TITLE
feat: Add autocomplete for log history fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                     </div>
                     ${isEditing ? `<input type="text" value="${child.name}" class="text-3xl font-bold text-center w-full bg-gray-700 rounded-md p-1 mb-2 ${colorTheme.text}"><div class="flex justify-center gap-3 my-4">${colorSwatchesHTML}</div><button data-action="save" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg">Save Changes</button>` : `<h2 class="text-3xl font-bold text-center mb-6 ${colorTheme.text}">${child.name}</h2>`}
                 </div>
-                ${!isEditing ? `<form class="space-y-4"><input type="hidden" name="childId" value="${child.id}"><div><label class="block text-sm font-medium text-gray-300">What?</label><input type="text" name="what" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: Tylenol"></div><div><label class="block text-sm font-medium text-gray-300">Quantity</label><input type="text" name="howMuch" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: 5 ml"></div><div><label class="block text-sm font-medium text-gray-300">When?</label><div class="flex items-center gap-2 mt-1"><input type="time" name="when" required class="block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}"><button type="button" data-action="setNow" class="bg-cyan-600 hover:bg-cyan-700 text-white font-semibold py-2 px-4 rounded-md text-sm whitespace-nowrap">Now</button></div></div><button type="submit" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg transform hover:scale-105">Log Medication</button></form><div class="mt-8 flex-grow flex flex-col"><div class="flex justify-between items-center"><h3 class="text-xl font-semibold text-gray-200">Log History</h3><button data-action="clearLog" class="text-sm bg-gray-700 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md">Clear Log</button></div><ul class="log-list mt-4 space-y-3 max-h-60 overflow-y-auto pr-2 flex-grow"></ul></div>` : ''}
+                ${!isEditing ? `<form class="space-y-4"><input type="hidden" name="childId" value="${child.id}"><div><label class="block text-sm font-medium text-gray-300">What?</label><input type="text" name="what" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: Tylenol" list="what-suggestions-${child.id}"><datalist id="what-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">Quantity</label><input type="text" name="howMuch" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: 5 ml" list="howMuch-suggestions-${child.id}"><datalist id="howMuch-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">When?</label><div class="flex items-center gap-2 mt-1"><input type="time" name="when" required class="block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}"><button type="button" data-action="setNow" class="bg-cyan-600 hover:bg-cyan-700 text-white font-semibold py-2 px-4 rounded-md text-sm whitespace-nowrap">Now</button></div></div><button type="submit" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg transform hover:scale-105">Log Medication</button></form><div class="mt-8 flex-grow flex flex-col"><div class="flex justify-between items-center"><h3 class="text-xl font-semibold text-gray-200">Log History</h3><button data-action="clearLog" class="text-sm bg-gray-700 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md">Clear Log</button></div><ul class="log-list mt-4 space-y-3 max-h-60 overflow-y-auto pr-2 flex-grow"></ul></div>` : ''}
             </div>`;
         }
 
@@ -259,8 +259,10 @@
                     state.listeners[child.id] = onSnapshot(query(logsRef, orderBy('timestamp', 'desc')), snapshot => {
                         const childIndex = state.children.findIndex(c => c.id === child.id);
                         if (childIndex > -1) {
-                            state.children[childIndex].logs = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-                            renderLogs(child.id, state.children[childIndex].logs);
+                            const logs = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                            state.children[childIndex].logs = logs;
+                            renderLogs(child.id, logs);
+                            updateAutocompleteSuggestions(child.id, logs);
                         }
                     });
                 }
@@ -422,6 +424,19 @@
                 }
                 logUl.innerHTML += logHTML;
             });
+        }
+
+        function updateAutocompleteSuggestions(childId, logs) {
+            const whatDatalist = document.getElementById(`what-suggestions-${childId}`);
+            const howMuchDatalist = document.getElementById(`howMuch-suggestions-${childId}`);
+
+            if (!whatDatalist || !howMuchDatalist) return;
+
+            const whatSuggestions = new Set(logs.map(log => log.what));
+            const howMuchSuggestions = new Set(logs.map(log => log.howMuch));
+
+            whatDatalist.innerHTML = [...whatSuggestions].map(suggestion => `<option value="${suggestion}"></option>`).join('');
+            howMuchDatalist.innerHTML = [...howMuchSuggestions].map(suggestion => `<option value="${suggestion}"></option>`).join('');
         }
 
         // --- GLOBAL ACTIONS ---


### PR DESCRIPTION
This commit introduces an autocompletion feature for the "What?" and "Quantity" input fields on the medication log form.

- The `createCardHTML` function has been updated to include `<datalist>` elements associated with the "What?" and "Quantity" inputs.
- A new function, `updateAutocompleteSuggestions`, has been created to populate these datalists with unique, historical log entries for the specific card.
- This new function is called within the Firestore `onSnapshot` listener, ensuring that the autocompletion suggestions are always up-to-date with the latest log data.