### PR TITLE
Fix duplicate autocomplete suggestions by trimming whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,8 +305,8 @@
                         renderLogs(childId, childToUpdate.logs);
                         break;
                     case 'saveLog':
-                        const what = logLi.querySelector('[name="editWhat"]').value;
-                        const howMuch = logLi.querySelector('[name="editHowMuch"]').value;
+                        const what = logLi.querySelector('[name="editWhat"]').value.trim();
+                        const howMuch = logLi.querySelector('[name="editHowMuch"]').value.trim();
                         const when = logLi.querySelector('[name="editWhen"]').value;
                         const logRef = doc(db, 'users', userId, 'logs', childId, 'entries', logId);
                         await updateDoc(logRef, { what, howMuch, when });
@@ -366,8 +366,8 @@
             const childId = formData.get('childId');
             const now = new Date();
             const newLog = {
-                what: formData.get('what'),
-                howMuch: formData.get('howMuch'),
+                what: formData.get('what').trim(),
+                howMuch: formData.get('howMuch').trim(),
                 when: formData.get('when'),
                 date: now.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
                 timestamp: now
@@ -432,8 +432,8 @@
 
             if (!whatDatalist || !howMuchDatalist) return;
 
-            const whatSuggestions = new Set(logs.map(log => log.what));
-            const howMuchSuggestions = new Set(logs.map(log => log.howMuch));
+            const whatSuggestions = new Set(logs.map(log => log.what ? log.what.trim() : log.what));
+            const howMuchSuggestions = new Set(logs.map(log => log.howMuch ? log.howMuch.trim() : log.howMuch));
 
             whatDatalist.innerHTML = [...whatSuggestions].map(suggestion => `<option value="${suggestion}"></option>`).join('');
             howMuchDatalist.innerHTML = [...howMuchSuggestions].map(suggestion => `<option value="${suggestion}"></option>`).join('');


### PR DESCRIPTION
The autocomplete suggestions were showing duplicate entries for the same medication if there were differences in leading or trailing whitespace (e.g., "Dolip" and "Dolip ").

This commit fixes the issue in three ways:
1.  The `updateAutocompleteSuggestions` function now trims whitespace from log entries before creating the suggestion set. This ensures existing entries with whitespace are displayed correctly.
2.  The `handleFormSubmit` function now trims user input when creating new log entries.
3.  The `handleCardAction` function now trims user input when editing existing log entries.

These changes prevent duplicates in the autocomplete list and improve the overall data quality of the application.