### PR TITLE
feat: Reset log for the day instead of clearing all

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                     </div>
                     ${isEditing ? `<input type="text" value="${child.name}" class="text-3xl font-bold text-center w-full bg-gray-700 rounded-md p-1 mb-2 ${colorTheme.text}"><div class="flex justify-center gap-3 my-4">${colorSwatchesHTML}</div><button data-action="save" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg">Save Changes</button>` : `<h2 class="text-3xl font-bold text-center mb-6 ${colorTheme.text}">${child.name}</h2>`}
                 </div>
-                ${!isEditing ? `<form class="space-y-4"><input type="hidden" name="childId" value="${child.id}"><div><label class="block text-sm font-medium text-gray-300">What?</label><input type="text" name="what" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: Tylenol" list="what-suggestions-${child.id}"><datalist id="what-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">Quantity</label><input type="text" name="howMuch" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: 5 ml" list="howMuch-suggestions-${child.id}"><datalist id="howMuch-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">When?</label><div class="flex items-center gap-2 mt-1"><input type="time" name="when" required class="block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}"><button type="button" data-action="setNow" class="bg-cyan-600 hover:bg-cyan-700 text-white font-semibold py-2 px-4 rounded-md text-sm whitespace-nowrap">Now</button></div></div><button type="submit" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg transform hover:scale-105">Log Medication</button></form><div class="mt-8 flex-grow flex flex-col"><div class="flex justify-between items-center"><h3 class="text-xl font-semibold text-gray-200">Log History</h3><button data-action="clearLog" class="text-sm bg-gray-700 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md">Clear Log</button></div><ul class="log-list mt-4 space-y-3 max-h-60 overflow-y-auto pr-2 flex-grow"></ul></div>` : ''}
+                ${!isEditing ? `<form class="space-y-4"><input type="hidden" name="childId" value="${child.id}"><div><label class="block text-sm font-medium text-gray-300">What?</label><input type="text" name="what" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: Tylenol" list="what-suggestions-${child.id}"><datalist id="what-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">Quantity</label><input type="text" name="howMuch" required class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}" placeholder="ex: 5 ml" list="howMuch-suggestions-${child.id}"><datalist id="howMuch-suggestions-${child.id}"></datalist></div><div><label class="block text-sm font-medium text-gray-300">When?</label><div class="flex items-center gap-2 mt-1"><input type="time" name="when" required class="block w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white focus:outline-none ${colorTheme.ring} ${colorTheme.border}"><button type="button" data-action="setNow" class="bg-cyan-600 hover:bg-cyan-700 text-white font-semibold py-2 px-4 rounded-md text-sm whitespace-nowrap">Now</button></div></div><button type="submit" class="w-full ${colorTheme.bg} ${colorTheme.hoverBg} text-white font-bold py-2 px-4 rounded-lg transform hover:scale-105">Log Medication</button></form><div class="mt-8 flex-grow flex flex-col"><div class="flex justify-between items-center"><h3 class="text-xl font-semibold text-gray-200">Log History</h3><button data-action="clearLog" class="text-sm bg-gray-700 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md">Reset for Today</button></div><ul class="log-list mt-4 space-y-3 max-h-60 overflow-y-auto pr-2 flex-grow"></ul></div>` : ''}
             </div>`;
         }
 
@@ -355,7 +355,7 @@
                     await updateDoc(doc(db, 'users', userId, 'children', childId), { name: newName, isEditing: false });
                     break;
                 case 'clearLog':
-                    showModal('clearLog', childId, `This will permanently delete all log entries for <strong class="${availableColors[child.color].text}">${child.name}</strong>.`);
+                    showModal('clearLog', childId, `This will permanently delete all log entries for <strong class="${availableColors[child.color].text}">${child.name}</strong> created before today. This will reset the log for the day.`);
                     break;
                 case 'setNow':
                     const whenInput = document.querySelector(`#${childId} input[name="when"]`);
@@ -485,17 +485,32 @@
                 const { childId, logId } = targetId;
                 const logRef = doc(db, 'users', userId, 'logs', childId, 'entries', logId);
                 await deleteDoc(logRef);
-            } else {
+            } else if (type === 'clearLog') {
                 const batch = writeBatch(db);
-                if (type === 'clearLog' || type === 'deleteCard') {
-                    const logsRef = collection(db, 'users', userId, 'logs', targetId, 'entries');
-                    const logsSnapshot = await getDocs(logsRef);
-                    logsSnapshot.forEach(doc => batch.delete(doc.ref));
-                }
-                if (type === 'deleteCard') {
-                    const childRef = doc(db, 'users', userId, 'children', targetId);
-                    batch.delete(childRef);
-                }
+                const logsRef = collection(db, 'users', userId, 'logs', targetId, 'entries');
+                const logsSnapshot = await getDocs(logsRef);
+
+                const today = new Date();
+                today.setHours(0, 0, 0, 0);
+
+                logsSnapshot.forEach(doc => {
+                    const logTimestamp = doc.data().timestamp.toDate();
+                    if (logTimestamp < today) {
+                        batch.delete(doc.ref);
+                    }
+                });
+                await batch.commit();
+            } else if (type === 'deleteCard') {
+                const batch = writeBatch(db);
+                // Also delete all logs for the card
+                const logsRef = collection(db, 'users', userId, 'logs', targetId, 'entries');
+                const logsSnapshot = await getDocs(logsRef);
+                logsSnapshot.forEach(doc => batch.delete(doc.ref));
+
+                // Delete the card itself
+                const childRef = doc(db, 'users', userId, 'children', targetId);
+                batch.delete(childRef);
+
                 await batch.commit();
             }
 


### PR DESCRIPTION
This commit changes the 'Clear Log' functionality to only delete log entries that were not created on the current day. This allows users to reset their log for the day without losing all historical data.

The changes include:
- Updating the button text from 'Clear Log' to 'Reset for Today'.
- Modifying the confirmation modal to reflect the new behavior.
- Implementing the logic in `confirmModalAction` to compare log timestamps with the start of the current day and only delete older entries.